### PR TITLE
Fix macOS DMG packaging to exclude extra artifacts

### DIFF
--- a/scripts/build_macos.sh
+++ b/scripts/build_macos.sh
@@ -45,6 +45,7 @@ APP_BUNDLE="${APP_NAME}.app"
 DMG_PATH="$DIST_DIR/LaTeXSnipper_${VERSION}_${ARCH_LABEL}.dmg"
 APP_ZIP_PATH="$DIST_DIR/LaTeXSnipper_${VERSION}_${ARCH_LABEL}.app.zip"
 BUILD_WORK_DIR="$PROJECT_ROOT/build/pyinstaller_macos"
+DMG_STAGING_DIR="$PROJECT_ROOT/build/dmg_staging_macos"
 SPEC_FILE="$PROJECT_ROOT/LaTeXSnipper-macos.spec"
 ICON_SOURCE="$PROJECT_ROOT/src/assets/icon.ico"
 ICNS_PATH=""
@@ -68,7 +69,7 @@ if [[ -n "$ICNS_PATH" ]]; then
 fi
 
 log_step "2/6" "Cleaning previous outputs"
-rm -rf "$BUILD_WORK_DIR" "$DIST_DIR/$APP_NAME" "$DIST_DIR/$APP_BUNDLE" "$DMG_PATH" "$APP_ZIP_PATH"
+rm -rf "$BUILD_WORK_DIR" "$DMG_STAGING_DIR" "$DIST_DIR/$APP_NAME" "$DIST_DIR/$APP_BUNDLE" "$DMG_PATH" "$APP_ZIP_PATH"
 
 log_step "3/6" "Running PyInstaller"
 cd "$PROJECT_ROOT"
@@ -118,16 +119,20 @@ log_step "6/6" "Packaging app artifacts"
 ditto -c -k --keepParent "$APP_PATH" "$APP_ZIP_PATH"
 
 if command -v create-dmg >/dev/null 2>&1; then
+    rm -rf "$DMG_STAGING_DIR"
+    mkdir -p "$DMG_STAGING_DIR"
+    ditto "$APP_PATH" "$DMG_STAGING_DIR/$APP_BUNDLE"
+
     CREATE_DMG_ARGS=(
         --volname "LaTeXSnipper ${VERSION}"
         --window-pos 200 120
         --window-size 600 400
         --icon-size 100
-        --icon "$APP_NAME.app" 150 190
-        --hide-extension "$APP_NAME.app"
+        --icon "$APP_BUNDLE" 150 190
+        --hide-extension "$APP_BUNDLE"
         --app-drop-link 450 185
         "$DMG_PATH"
-        "$(dirname "$APP_PATH")"
+        "$DMG_STAGING_DIR"
     )
     if [[ -f "$ICNS_PATH" ]]; then
         CREATE_DMG_ARGS=(--volicon "$ICNS_PATH" "${CREATE_DMG_ARGS[@]}")


### PR DESCRIPTION
## 概述

这个 PR 修复了 macOS DMG 安装包打包时可能包含多余构建产物的问题。

之前脚本在调用 `create-dmg` 时，直接把生成的 app 所在目录作为 source folder 传入。如果该目录中同时存在其他构建产物，例如 PyInstaller 输出目录或 `.app.zip` 文件，这些文件也可能被一起打进最终的 DMG 中，导致用户打开安装包时看到多余文件。

本次修改新增了一个专门的 DMG staging 目录，在调用 `create-dmg` 前只把生成的 `LaTeXSnipper.app` 复制进去，然后使用这个干净的 staging 目录作为 DMG source folder。

## 修改内容

- 新增专门的 DMG staging 目录
- 在清理阶段同时清理 staging 目录
- 在生成 DMG 前，只复制 `LaTeXSnipper.app` 到 staging 目录
- 使用 staging 目录作为 `create-dmg` 的 source folder
- 保持 `.app.zip` 产物生成逻辑不变

## 期望效果

生成的 DMG 中应该只包含：

- `LaTeXSnipper.app`
- `Applications` 快捷方式

不应该再包含：

- PyInstaller 输出目录
- `.app.zip` 文件
- 其他构建产物

## 验证情况

- 已运行 `bash -n scripts/build_macos.sh`，脚本语法检查通过
- 已检查 diff，确认改动范围仅限于 macOS DMG 打包逻辑

由于我本地环境暂时没有完整配置 `create-dmg` 打包验证流程，因此没有在本机完整运行 DMG 构建和挂载检查。