### PR TITLE
fix: remove VSTO build from CI, use pre-built artifacts in repo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -254,8 +254,6 @@ jobs:
           $vsPath = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.ATL -property installationPath
           if (-not $vsPath) { throw "Visual Studio C++ ATL tools were not found." }
           $msbuild = Join-Path $vsPath "MSBuild\Current\Bin\amd64\MSBuild.exe"
-          Remove-ItemProperty -Path "HKLM:\Software\Microsoft\Fusion" -Name "EnableLog" -ErrorAction SilentlyContinue
-          .\tools\Build-VstoAddIns.ps1 -Configuration Release -MSBuildPath $msbuild
           dotnet build LaTeXSnipper.OfficePlugin.slnx -c Release
           & $msbuild hosts\OleFormulaObjectNative\LaTeXSnipper.OfficePlugin.OleFormulaObjectHandler.vcxproj /p:Configuration=Release /p:Platform=x64 /m
           if ($LASTEXITCODE -ne 0) { throw "Native OLE x64 build failed." }


### PR DESCRIPTION
- VSTO projects (WordVstoAddIn, PowerPointVstoAddIn) produce binaries that are pre-built and checked into the repo under bin/Release/
- The CI runner (VS 2025) lacks Microsoft.VisualStudio.Tools.Applications .Hosting assembly causing VerifyClickOnceSigningSettings to fail
- Local build.bat handles VSTO source compilation; CI reuses repo artifacts and builds only shared libraries via dotnet build