### PR TITLE
Pin release seed setuptools below 82

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Install build dependencies
         shell: pwsh
         run: |
-          python -m pip install --upgrade pip wheel setuptools
+          python -m pip install --upgrade pip wheel "setuptools<82"
           python -m pip install -r requirements.txt
           python -m pip install -r requirements-build.txt
 
@@ -103,7 +103,7 @@ jobs:
             throw "Bundled Python seed was not created: $target"
           }
           Remove-Item -LiteralPath $installer -Force
-          & (Join-Path $target "python.exe") -m pip install --upgrade pip wheel setuptools
+          & (Join-Path $target "python.exe") -m pip install --upgrade pip wheel "setuptools<82"
 
       - name: Build unsigned installer
         shell: pwsh


### PR DESCRIPTION
## Summary

- Pin Release Build workflow seed upgrades to setuptools<82.
- Avoid setuptools 82 _distutils_hack assertion when verifying the bundled Python 3.11 seed.

## Validation

- Verified release.yml no longer contains unbounded setuptools upgrade commands.
