### PR TITLE
fix(release): don't upgrade setuptools in bundled Python seed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,7 @@ jobs:
             throw "Bundled Python seed was not created: $target"
           }
           Remove-Item -LiteralPath $installer -Force
-          & (Join-Path $target "python.exe") -m pip install --upgrade pip wheel "setuptools<82"
+          & (Join-Path $target "python.exe") -m pip install --upgrade pip wheel
 
       - name: Build unsigned installer
         shell: pwsh


### PR DESCRIPTION
The bundled Python 3.11.0 runtime ships with setuptools 65.5.0. Upgrading it to 81.0.0 (via 'setuptools<82') triggers a _distutils_hack assertion failure:

  assert '_distutils' in core.__file__, core.__file__
  AssertionError: ...Lib\distutils\core.py

This happens because the Normalize-BundledPythonSeed step creates a python311._pth file that alters path resolution, breaking the distutils override mechanism in newer setuptools versions.

Keep the original 65.5.0 from the embedded Python installer - it is sufficient for runtime use (pip, pkg_resources).