### PR TITLE
fix(release): remove module import verification from bundled Python seed normalization

### DIFF
--- a/scripts/build_github_release_installer.ps1
+++ b/scripts/build_github_release_installer.ps1
@@ -324,8 +324,6 @@ if pathlib.Path(sys.base_prefix).resolve() != root:
     raise SystemExit("sys.base_prefix does not point to bundled python311")
 if bad:
     raise SystemExit("sys.path contains paths outside bundled python311")
-for mod in ("pip", "setuptools", "wheel", "packaging"):
-    importlib.import_module(mod)
 '@
     $verifyScript = Join-Path ([System.IO.Path]::GetTempPath()) ("latexsnipper_verify_python_seed_{0}.py" -f ([System.Guid]::NewGuid().ToString("N")))
     try {


### PR DESCRIPTION
## 问题

Release Build 的 Windows Installer 构建在  验证阶段失败，报错：



## 根因

提交 `ddcdee827` 在验证脚本中新增了两行代码：

```python
for mod in (pip, setuptools, wheel, packaging):
    importlib.import_module(mod)
```

`import setuptools` 触发了 `_distutils_hack.override` → `ensure_local_distutils()` 中的断言 `assert '_distutils' in core.__file__`，在 `python311._pth` 控制的 embedded Python 环境下断言必然失败。此前所有版本的 Normalize 验证只检查路径和 prefix，不导入模块，构建一直正常。

## 修复

去掉这两行验证代码，回归到 `dc203f457` 版本的行为——只验证路径完整性，不通过 import 模块来验证。模块完整性由 pip 安装步骤自身保证，删除这两行不会影响 bundled Python 的模块内容或运行时行为。