### PR TITLE
fix: remove setApplicationDisplayName and normalize main window title

### DIFF
--- a/src/runtime/app_runner.py
+++ b/src/runtime/app_runner.py
@@ -96,7 +96,6 @@ def run_application(main_window_cls) -> int:
 
     app = QApplication.instance() or QApplication(sys.argv)
     app.setApplicationName("LaTeXSnipper")
-    app.setApplicationDisplayName("LaTeXSnipper")
     app.setOrganizationName("MathCraft")
     app.setQuitOnLastWindowClosed(False)
 

--- a/src/ui/main_window_setup.py
+++ b/src/ui/main_window_setup.py
@@ -37,7 +37,7 @@ class MainWindowSetupMixin:
         self._startup_centered_once = False
         self._pending_hotkey_seq = None
 
-        self.setWindowTitle("LaTeX Snipper")
+        self.setWindowTitle("LaTeXSnipper")
         self.resize(1280, 760)
         self.setMinimumSize(1280, 760)
 


### PR DESCRIPTION
Remove  from [app_runner.py](src/runtime/app_runner.py#L99).

Recent Qt Windows platform plugin versions automatically append  to all QDialog window titles with  separator. This caused every dialog to show an unwanted  suffix.

Also normalize main window title in [main_window_setup.py](src/ui/main_window_setup.py#L40) from  to  for consistency.

 and  are kept for QSettings.