### PR TITLE
fix: Cancel the leftover thread from a previous Pandoc download attempt that was causing dual concurrent downloads upon retrying.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,7 @@ release_v*.md
 release*.md
 packaging/msix/image/
 
+# IDE / editor config
+.opencode/
+opencode.json
+

--- a/src/bootstrap/deps_pandoc.py
+++ b/src/bootstrap/deps_pandoc.py
@@ -7,8 +7,13 @@ from bootstrap.deps_context import flags
 from runtime.app_paths import app_tools_dir
 
 
-def _ensure_pandoc_binary(pyexe: str, log_fn=None, progress_fn=None) -> bool:
+def _ensure_pandoc_binary(pyexe: str, log_fn=None, progress_fn=None, stop_event=None) -> bool:
     """Ensure the pandoc executable is available."""
+    if stop_event and stop_event.is_set():
+        if log_fn:
+            log_fn("[INFO] Pandoc: 下载已取消")
+        return False
+
     if log_fn:
         log_fn("[INFO] Pandoc: 正在检查 pandoc 二进制文件...")
 
@@ -53,11 +58,16 @@ def _ensure_pandoc_binary(pyexe: str, log_fn=None, progress_fn=None) -> bool:
 
 
     _cleanup_pandoc_leftovers(pyexe, log_fn)
+    if stop_event and stop_event.is_set():
+        if log_fn:
+            log_fn("[INFO] Pandoc: 下载已取消")
+        return False
+
     if log_fn:
         log_fn("[INFO] Pandoc: 从镜像下载 pandoc 二进制...")
     if progress_fn:
         progress_fn(85)
-    ok = _download_pandoc_from_mirrors(pyexe, log_fn)
+    ok = _download_pandoc_from_mirrors(pyexe, log_fn, stop_event=stop_event)
     if ok:
         if log_fn:
             log_fn("[INFO] Pandoc: pandoc 二进制文件就绪")
@@ -273,7 +283,7 @@ def _rank_mirrors_by_speed(mirrors: list[str], log_fn=None) -> list[str]:
     return ranked
 
 
-def _download_pandoc_from_mirrors(pyexe: str | None = None, log_fn=None) -> bool:
+def _download_pandoc_from_mirrors(pyexe: str | None = None, log_fn=None, stop_event=None) -> bool:
     """Download pandoc and extract it into the shared app tools directory."""
     import urllib.request
     import time as _time
@@ -297,6 +307,10 @@ def _download_pandoc_from_mirrors(pyexe: str | None = None, log_fn=None) -> bool
     mirrors = _rank_mirrors_by_speed(mirrors, log_fn)
 
     for idx, url in enumerate(mirrors, start=1):
+        if stop_event and stop_event.is_set():
+            if log_fn:
+                log_fn("[INFO] Pandoc: 下载已取消")
+            return False
         if log_fn:
             log_fn(f"[INFO] Pandoc: [{idx}/{len(mirrors)}] 尝试: {url[:80]}...")
         try:
@@ -317,6 +331,11 @@ def _download_pandoc_from_mirrors(pyexe: str | None = None, log_fn=None) -> bool
                 chunk = resp.read(chunk_size)
                 if not chunk:
                     break
+                if stop_event and stop_event.is_set():
+                    resp.close()
+                    if log_fn:
+                        log_fn("[INFO] Pandoc: 下载已取消")
+                    return False
                 chunks.append(chunk)
                 downloaded += len(chunk)
 

--- a/src/bootstrap/deps_workers.py
+++ b/src/bootstrap/deps_workers.py
@@ -279,6 +279,11 @@ class InstallWorker(QThread):
 
             pandoc_ok = True
             if want_pandoc:
+                if self.stop_event.is_set():
+                    self.log_updated.emit("[INFO] Pandoc: 下载已取消")
+                    self._emit_done_safe(False)
+                    return
+
                 base_progress = pip_progress_max if pending else 20
                 self.log_updated.emit("[INFO] Pandoc: 检查 pandoc 二进制文件...")
 
@@ -291,6 +296,7 @@ class InstallWorker(QThread):
                     self.pyexe,
                     self.log_updated.emit,
                     progress_fn=_pandoc_progress,
+                    stop_event=self.stop_event,
                 )
 
             if "CORE" in chosen_layers or any(layer in chosen_layers for layer in MATHCRAFT_RUNTIME_LAYERS):


### PR DESCRIPTION
---
issue:
Fixes #329

---
reason:
_download_pandoc_from_mirrors 的 urllib 下载循环未检查 stop_event, 取消下载后 worker.wait() 超时, 旧 QThread 继续后台下载。
用户重新下载时新线程也启动, 形成两个甚至更多的并发 Pandoc 下载。

---
fix:
- deps_pandoc.py: _ensure_pandoc_binary / _download_pandoc_from_mirrors 新增 stop_event 参数, 在函数入口、镜像切换前、chunk 循环内共 3 处取消检查
- deps_workers.py: InstallWorker.run() 传入 stop_event 并在 Pandoc 下载前预检查