### PR TITLE
修正 MinerU PDF DPI 流程与打包测试兼容性

### DIFF
--- a/LaTeXSnipper-linux.spec
+++ b/LaTeXSnipper-linux.spec
@@ -22,11 +22,13 @@ sys.setrecursionlimit(max(5000, sys.getrecursionlimit() * 5))
 # ---------------------------------------------------------------------------
 ROOT = Path(SPECPATH)
 SRC = ROOT / "src"
+SCRIPTS = ROOT / "scripts"
 APP_NAME = os.environ.get("LATEXSNIPPER_BUILD_NAME", "LaTeXSnipper")
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
+if str(SCRIPTS) in sys.path:
+    sys.path.remove(str(SCRIPTS))
+sys.path.insert(0, str(SCRIPTS))
 
-from scripts.linux_hotkey_packaging import collect_linux_hotkey_modules
+from linux_hotkey_packaging import collect_linux_hotkey_modules
 
 print(f"[SPEC] output name: {APP_NAME}")
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -173,7 +173,7 @@ The dependency wizard manages the optional `PANDOC` layer. Manually downloaded o
 
 ## How does PDF recognition work?
 
-Use the main window's PDF recognition button and choose the page count, output format, and render DPI. Built-in MathCraft PDF recognition uses mixed mode because PDF pages need both text and formula recovery. External providers must be configured first; MinerU native mode uses document parsing and returns Markdown.
+Use the main window's PDF recognition button and choose the page count, output format, and render DPI. Built-in MathCraft PDF recognition uses mixed mode because PDF pages need both text and formula recovery. External providers must be configured first. MinerU native mode sends the original PDF for document parsing, returns Markdown, and does not ask for render DPI.
 
 The PDF result window lets you edit, copy, and save the recognized document. Markdown saves also copy structured image assets when the provider returns them.
 
@@ -183,7 +183,7 @@ LaTeXSnipper supports the built-in MathCraft OCR path and external providers suc
 
 The Base URL is the service root or the provider's `/v1` API prefix, not a concrete endpoint. The app appends protocol routes itself: Ollama uses `/api/tags` and `/api/chat`, OpenAI-compatible services use `/models` and `/chat/completions` under the resolved `/v1` prefix, and MinerU Local uses the configured health and parse paths.
 
-The prompt template determines both the request instructions and result type for normal image, screenshot, and handwriting recognition. A custom prompt replaces the built-in template for those paths and for OpenAI-compatible or Ollama PDF recognition. PDF output format and DPI are still selected at the PDF entry point; MinerU Local does not use prompts.
+The prompt template determines both the request instructions and result type for normal image, screenshot, and handwriting recognition. A custom prompt replaces the built-in template for those paths and for OpenAI-compatible or Ollama PDF recognition. Built-in MathCraft and OpenAI-compatible or Ollama PDF recognition select output format and render DPI at the PDF entry point. MinerU Local parses the original PDF and does not use prompts or render DPI.
 
 ## Why does Ollama fail when I use `/v1`?
 

--- a/scripts/verify_linux_hotkey_archive.py
+++ b/scripts/verify_linux_hotkey_archive.py
@@ -6,10 +6,12 @@ import sys
 
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
-if str(PROJECT_ROOT) not in sys.path:
-    sys.path.insert(0, str(PROJECT_ROOT))
+SCRIPTS_DIR = PROJECT_ROOT / "scripts"
+if str(SCRIPTS_DIR) in sys.path:
+    sys.path.remove(str(SCRIPTS_DIR))
+sys.path.insert(0, str(SCRIPTS_DIR))
 
-from scripts.linux_hotkey_packaging import REQUIRED_LINUX_HOTKEY_MODULES
+from linux_hotkey_packaging import REQUIRED_LINUX_HOTKEY_MODULES
 
 
 def main() -> int:

--- a/src/backend/external_model/pdf_worker.py
+++ b/src/backend/external_model/pdf_worker.py
@@ -19,7 +19,7 @@ class ExternalModelPdfWorker(QObject):
         pdf_path: str,
         page_indices: list[int],
         output_format: str,
-        dpi: int = 200,
+        dpi: int | None = 200,
         document_mode: str = "document",
     ):
         super().__init__()
@@ -27,7 +27,7 @@ class ExternalModelPdfWorker(QObject):
         self.pdf_path = pdf_path
         self.page_indices = [int(index) for index in page_indices if int(index) >= 0]
         self.output_format = output_format
-        self.dpi = dpi
+        self.dpi = int(dpi) if dpi is not None else None
         self.document_mode = str(document_mode or "document").strip().lower() or "document"
         self._cancelled = False
         self.elapsed = None
@@ -72,6 +72,11 @@ class ExternalModelPdfWorker(QObject):
                 self.failed.emit(str(e))
                 return
 
+        if self.dpi is None:
+            _set_elapsed()
+            self.failed.emit("PDF 渲染 DPI 未设置")
+            return
+
         try:
             import fitz  # PyMuPDF
         except Exception as e:
@@ -114,7 +119,8 @@ class ExternalModelPdfWorker(QObject):
                     self.failed.emit("已取消")
                     return
                 page = doc.load_page(page_index)
-                pix = page.get_pixmap(dpi=int(max(self.dpi, 72)), alpha=False)
+                render_dpi = max(self.dpi, 72)
+                pix = page.get_pixmap(dpi=render_dpi, alpha=False)
                 image = Image.frombytes("RGB", (pix.width, pix.height), pix.samples)
                 page_result = pipeline.process_page(image, page_index + 1, self.config.prompt_template)
                 if page_result:

--- a/src/recognition/pdf_controller.py
+++ b/src/recognition/pdf_controller.py
@@ -161,6 +161,8 @@ class PdfRecognitionControllerMixin:
                 doc_mode,
             )
         else:
+            if dpi is None:
+                raise RuntimeError("内置 PDF 识别缺少渲染 DPI")
             self.pdf_predict_worker = PdfPredictWorker(
                 self.model,
                 str(path),

--- a/src/ui/pdf_options_dialog.py
+++ b/src/ui/pdf_options_dialog.py
@@ -40,7 +40,11 @@ def _pick_item(parent, title: str, label: str, items: list[str], current: int = 
     return dlg.textValue()
 
 
-def prompt_pdf_output_options(parent, current_model: str, external_config=None):
+def prompt_pdf_output_options(
+    parent,
+    current_model: str,
+    external_config=None,
+) -> tuple[str, int | None, str] | None:
     """Prompt for PDF recognition output format and DPI."""
     doc_mode = "document"
     external_provider = external_config.normalized_provider() if external_config is not None else ""
@@ -49,13 +53,13 @@ def prompt_pdf_output_options(parent, current_model: str, external_config=None):
         doc_mode = "parse"
 
     if doc_mode == "parse":
-        fmt_key = "markdown"
-    else:
-        fmt_items = ["Markdown", "LaTeX"]
-        fmt = _pick_item(parent, "导出格式", "请选择导出格式：", fmt_items, 0)
-        if not fmt:
-            return None
-        fmt_key = "markdown" if fmt.lower().startswith("markdown") else "latex"
+        return "markdown", None, doc_mode
+
+    fmt_items = ["Markdown", "LaTeX"]
+    fmt = _pick_item(parent, "导出格式", "请选择导出格式：", fmt_items, 0)
+    if not fmt:
+        return None
+    fmt_key = "markdown" if fmt.lower().startswith("markdown") else "latex"
 
     dlg = QDialog(parent)
     dlg.setWindowTitle("PDF 渲染分辨率")
@@ -94,7 +98,11 @@ def prompt_pdf_output_options(parent, current_model: str, external_config=None):
     slider.setValue(default_dpi)
     layout.addWidget(slider)
 
-    tip = QLabel("建议根据文档清晰度动态调整：清晰文档可用较低 DPI，普通文档建议 140-170 DPI，模糊文档可适当提高；过高 DPI 可能降低识别稳定性。")
+    tip = QLabel(
+        "清晰文字型 PDF 建议 140-170 DPI，扫描件可尝试 200-300 DPI。"
+        "提高 DPI 仅在原页面细节不足时有帮助；过高会增加内存和处理时间，"
+        "使用外部模型时还可能触发缩放、输入限制或超时。"
+    )
     tip.setWordWrap(True)
     tip.setStyleSheet(f"color: {dialog_theme_tokens()['muted']}; font-size: 11px;")
     layout.addWidget(tip)
@@ -105,7 +113,7 @@ def prompt_pdf_output_options(parent, current_model: str, external_config=None):
         elif 140 <= value <= 170:
             zone = "推荐"
         elif value > 220:
-            zone = "高 DPI：模糊文档"
+            zone = "高 DPI：扫描件"
         else:
             zone = "可选"
         dpi_label.setText(f"当前 DPI：{value}（{zone}）")
@@ -118,7 +126,7 @@ def prompt_pdf_output_options(parent, current_model: str, external_config=None):
     buttons.rejected.connect(dlg.reject)
     layout.addWidget(buttons)
 
-    dlg.setFixedSize(420, 180)
+    dlg.setFixedSize(460, 210)
     if dlg.exec() != int(QDialog.DialogCode.Accepted):
         return None
     dpi = int(slider.value())

--- a/src/ui/settings_external_help.py
+++ b/src/ui/settings_external_help.py
@@ -59,7 +59,7 @@ class ExternalModelHelpWindow(QDialog):
         self._add_section(
             content_layout,
             "提示词边界",
-            "提示词模板决定普通图片和截图识别的请求内容与结果类型。手写识别固定使用混合文档类型，PDF 导出格式和 DPI 在 PDF 入口选择。自定义提示词优先级最高，会覆盖这些入口的内置提示词；MinerU Local 不使用提示词。",
+            "提示词模板决定普通图片和截图识别的请求内容与结果类型。手写识别固定使用混合文档类型；内置模型及 OpenAI-compatible / Ollama 的 PDF 导出格式和 DPI 在 PDF 入口选择。自定义提示词优先级最高，会覆盖这些入口的内置提示词；MinerU Local 直接解析原 PDF，不使用提示词或渲染 DPI。",
         )
         self._add_section(
             content_layout,

--- a/test/test_linux_hotkey_packaging.py
+++ b/test/test_linux_hotkey_packaging.py
@@ -12,13 +12,15 @@ from unittest import mock
 
 
 ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS_DIR = ROOT / "scripts"
 VERIFIER = ROOT / "scripts" / "verify_linux_hotkey_archive.py"
 PACKAGE_COMMON = ROOT / "scripts" / "package_common.sh"
 BASH = shutil.which("bash")
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
+if str(SCRIPTS_DIR) in sys.path:
+    sys.path.remove(str(SCRIPTS_DIR))
+sys.path.insert(0, str(SCRIPTS_DIR))
 
-from scripts import linux_hotkey_packaging
+import linux_hotkey_packaging
 
 
 PYNPUT_MODULES = (
@@ -166,7 +168,10 @@ class LinuxHotkeyArchiveVerifierTests(unittest.TestCase):
 
 
 class DebianPackageArtifactCleanupTests(unittest.TestCase):
-    @unittest.skipUnless(BASH, "bash is required for Debian packaging tests")
+    @unittest.skipUnless(
+        sys.platform.startswith("linux") and BASH,
+        "Linux and bash are required for Debian packaging tests",
+    )
     def test_removes_only_requested_stale_package_outputs(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             output_directory = Path(temporary_directory)

--- a/test/test_pdf_options_dialog.py
+++ b/test/test_pdf_options_dialog.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import pytest
+
+from backend.external_model.schemas import ExternalModelConfig
+from ui import pdf_options_dialog
+
+
+def test_mineru_parse_mode_skips_pdf_dpi_dialog(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail_if_dialog_is_created(*_args, **_kwargs):
+        pytest.fail("MinerU native PDF parsing must not create a DPI dialog")
+
+    monkeypatch.setattr(pdf_options_dialog, "QDialog", fail_if_dialog_is_created)
+
+    result = pdf_options_dialog.prompt_pdf_output_options(
+        None,
+        "external_model",
+        ExternalModelConfig(provider="mineru"),
+    )
+
+    assert result == ("markdown", None, "parse")

--- a/user_manual/user_manual.md
+++ b/user_manual/user_manual.md
@@ -151,7 +151,7 @@ LaTeXSnipper 首次启动或检测到关键依赖缺失时会弹出"依赖向导
 - **内置模型：** 使用 MathCraft OCR。本地识别类型可选 **公式**、**混合（文字+公式）**、**纯文字**。
 - **外部模型：** 连接 OpenAI-compatible、Ollama 或 MinerU Local 服务。推荐预设包括 GLM-OCR、PaddleOCR-VL（FastDeploy）、Qwen2.5/Qwen3-VL 和 MinerU Local。
 
-外部模型的 **提示词模板** 决定普通图片和截图识别的请求内容与结果类型，可选公式、Markdown 或纯文本。手写识别固定使用混合文档类型，PDF 入口会单独询问导出格式和 DPI。填写 **自定义提示词** 后，自定义提示词优先级最高，会覆盖图片、截图、手写以及 OpenAI-compatible / Ollama PDF 识别的默认提示词；MinerU Local 不使用提示词。
+外部模型的 **提示词模板** 决定普通图片和截图识别的请求内容与结果类型，可选公式、Markdown 或纯文本。手写识别固定使用混合文档类型；内置模型及 OpenAI-compatible / Ollama 的 PDF 入口会单独询问导出格式和 DPI。填写 **自定义提示词** 后，自定义提示词优先级最高，会覆盖图片、截图、手写以及 OpenAI-compatible / Ollama PDF 识别的默认提示词；MinerU Local 直接解析原 PDF，不使用提示词或渲染 DPI。
 
 普通图片和截图的确认窗口、历史记录及主窗口预览会按结果类型渲染：LaTeX 使用公式预览，Markdown 使用混合预览，纯文本使用文本预览。本地 MathCraft 的公式、混合和纯文字结果遵循相同映射。
 
@@ -165,7 +165,7 @@ LaTeXSnipper 首次启动或检测到关键依赖缺失时会弹出"依赖向导
 - 当前为 **外部模型** 时，必须先在设置中完成外部模型配置并通过连接测试。
 - MinerU Local 会走文档解析模式，输出固定为 Markdown；其他模型会先询问输出 Markdown 还是 LaTeX。
 - 程序会询问识别页码或连续范围，例如 `5`、`3-7`；默认先填入 `1-5`，避免大 PDF 一次性耗时过长。
-- 程序会询问 PDF 渲染 DPI，范围为 90-300。外部模型默认 150 DPI，内置模型默认 200 DPI。
+- 内置模型及 OpenAI-compatible / Ollama 会询问 PDF 渲染 DPI，范围为 90-300；OpenAI-compatible / Ollama 默认 150 DPI，内置模型默认 200 DPI。MinerU Local 直接解析原 PDF，不显示 DPI 选择。
 - 识别结果会打开独立的 PDF 结果窗口，可编辑、复制或保存。Markdown 文档保存时，如果结构化结果包含图片资源，程序会尽量把相关 assets 一起复制到保存目录。
 
 ## 本地模型（MathCraft ONNX）相关问题
@@ -576,7 +576,7 @@ LaTeXSnipper 卸载默认保留用户数据，方便升级或重装后继续使�
 
 **原因：**
 
-- DPI 设得太低（< 100）或太高（> 200）
+- DPI 过低会丢失小字和细线细节；过高会增加内存和处理时间，使用外部模型时还可能触发缩放、输入限制或超时
 - 扫描件与文字型 PDF 处理方式不同
 - 提示词模板不匹配（用了公式模板去识别文档）
 
@@ -585,7 +585,7 @@ LaTeXSnipper 卸载默认保留用户数据，方便升级或重装后继续使�
 - 文字型 PDF：尝试 140-170 DPI
 - 扫描件：尝试 200-300 DPI
 - 外部模型普通图片识别：确认设置中的提示词模板与任务匹配；手写识别固定使用混合文档类型
-- PDF 识别：在 PDF 入口单独选择 Markdown/LaTeX 与 DPI；MinerU 文档解析固定输出 Markdown
+- PDF 识别：内置模型及 OpenAI-compatible / Ollama 在 PDF 入口单独选择 Markdown/LaTeX 与 DPI；MinerU 文档解析直接使用原 PDF 并固定输出 Markdown
 
 ### 切换了输出模式但结果没变
 

--- a/user_manual/user_manual.typ
+++ b/user_manual/user_manual.typ
@@ -267,7 +267,7 @@ LaTeXSnipper 首次启动或检测到关键依赖缺失时会弹出"依赖向导
 - #text(weight: "bold")[内置模型：] 使用 MathCraft OCR。本地识别类型可选 #text(weight: "bold")[公式]、#text(weight: "bold")[混合（文字+公式）]、#text(weight: "bold")[纯文字]。
 - #text(weight: "bold")[外部模型：] 连接 OpenAI-compatible、Ollama 或 MinerU Local 服务。推荐预设包括 GLM-OCR、PaddleOCR-VL（FastDeploy）、Qwen2.5/Qwen3-VL 和 MinerU Local。
 
-外部模型的 #text(weight: "bold")[提示词模板] 决定普通图片和截图识别的请求内容与结果类型，可选公式、Markdown 或纯文本。手写识别固定使用混合文档类型，PDF 入口会单独询问导出格式和 DPI。填写 #text(weight: "bold")[自定义提示词] 后，自定义提示词优先级最高，会覆盖图片、截图、手写以及 OpenAI-compatible / Ollama PDF 识别的默认提示词；MinerU Local 不使用提示词。
+外部模型的 #text(weight: "bold")[提示词模板] 决定普通图片和截图识别的请求内容与结果类型，可选公式、Markdown 或纯文本。手写识别固定使用混合文档类型；内置模型及 OpenAI-compatible / Ollama 的 PDF 入口会单独询问导出格式和 DPI。填写 #text(weight: "bold")[自定义提示词] 后，自定义提示词优先级最高，会覆盖图片、截图、手写以及 OpenAI-compatible / Ollama PDF 识别的默认提示词；MinerU Local 直接解析原 PDF，不使用提示词或渲染 DPI。
 
 普通图片和截图的确认窗口、历史记录及主窗口预览会按结果类型渲染：LaTeX 使用公式预览，Markdown 使用混合预览，纯文本使用文本预览。本地 MathCraft 的公式、混合和纯文字结果遵循相同映射。
 
@@ -281,7 +281,7 @@ LaTeXSnipper 首次启动或检测到关键依赖缺失时会弹出"依赖向导
 - 当前为 #text(weight: "bold")[外部模型] 时，必须先在设置中完成外部模型配置并通过连接测试。
 - MinerU Local 会走文档解析模式，输出固定为 Markdown；其他模型会先询问输出 Markdown 还是 LaTeX。
 - 程序会询问识别页码或连续范围，例如 `5`、`3-7`；默认先填入 `1-5`，避免大 PDF 一次性耗时过长。
-- 程序会询问 PDF 渲染 DPI，范围为 90-300。外部模型默认 150 DPI，内置模型默认 200 DPI。
+- 内置模型及 OpenAI-compatible / Ollama 会询问 PDF 渲染 DPI，范围为 90-300；OpenAI-compatible / Ollama 默认 150 DPI，内置模型默认 200 DPI。MinerU Local 直接解析原 PDF，不显示 DPI 选择。
 - 识别结果会打开独立的 PDF 结果窗口，可编辑、复制或保存。Markdown 文档保存时，如果结构化结果包含图片资源，程序会尽量把相关 assets 一起复制到保存目录。
 
 // ═══════════════════════════════════════════
@@ -759,7 +759,7 @@ LaTeXSnipper 卸载默认保留用户数据，方便升级或重装后继续使�
 #v(0.35em)
 
 *原因：*
-- DPI 设得太低（< 100）或太高（> 200）
+- DPI 过低会丢失小字和细线细节；过高会增加内存和处理时间，使用外部模型时还可能触发缩放、输入限制或超时
 - 扫描件与文字型 PDF 处理方式不同
 - 提示词模板不匹配（用了公式模板去识别文档）
 
@@ -769,7 +769,7 @@ LaTeXSnipper 卸载默认保留用户数据，方便升级或重装后继续使�
 - 文字型 PDF：尝试 140-170 DPI
 - 扫描件：尝试 200-300 DPI
 - 外部模型普通图片识别：确认设置中的提示词模板与任务匹配；手写识别固定使用混合文档类型
-- PDF 识别：在 PDF 入口单独选择 Markdown/LaTeX 与 DPI；MinerU 文档解析固定输出 Markdown
+- PDF 识别：内置模型及 OpenAI-compatible / Ollama 在 PDF 入口单独选择 Markdown/LaTeX 与 DPI；MinerU 文档解析直接使用原 PDF 并固定输出 Markdown
 
 == 切换了输出模式但结果没变
 


### PR DESCRIPTION
## 修改内容

- MinerU Local 原生解析 PDF 时直接使用原文件，不再显示无效的 DPI 对话框
- 内置模型、OpenAI-compatible 和 Ollama 保留 PDF 渲染 DPI 设置
- 统一修正 DPI 提示、设置帮助、FAQ 和中英文用户手册，明确高 DPI 的细节收益、性能开销及外部模型输入限制
- 增加 MinerU 跳过 DPI 对话框的回归测试
- 修复 Linux 打包脚本在存在同名 `scripts` 第三方包时的模块解析冲突
- Debian Bash 专项测试仅在 Linux 执行，避免 Windows Git Bash 路径语义造成误报

## 验证

- `300 passed, 1 skipped, 57 subtests passed`
- 跳过项为非 Linux 平台不适用的 Debian Bash 测试
- `git diff --check` 通过