### PR TITLE
docs: keep sponsorship QR codes visible in READMEs

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -113,14 +113,9 @@ LaTeXSnipper 是免费开源、无广告、无内购的个人项目。如果它�
 
 [LINUX DO 社区](https://linux.do/)
 
-<details>
-<summary>赞助与交流群二维码</summary>
-
 | 支付宝 | 微信 | 中文交流群 |
 |---|---|---|
 | <img width="240" alt="支付宝收款码" src="https://github.com/user-attachments/assets/1efa46b7-07cb-4a3e-821d-f23b7a36ab34" /> | <img width="240" alt="微信收款码" src="https://github.com/user-attachments/assets/19065b1d-ac40-478e-8318-fabb75488c5c" /> | <img width="240" alt="LaTeXSnipper 交流群二维码" src="https://github.com/user-attachments/assets/91c30d59-a4a7-4118-b24b-dada0fe002bf" /> |
-
-</details>
 
 ## 许可证
 

--- a/readme.md
+++ b/readme.md
@@ -113,14 +113,9 @@ LaTeXSnipper is a free, open-source, ad-free personal project with no in-app pur
 
 [LINUX DO Community](https://linux.do/)
 
-<details>
-<summary>Sponsorship and community QR codes</summary>
-
 | Alipay | WeChat Pay | Community chat (Chinese) |
 |---|---|---|
 | <img width="240" alt="Alipay donation QR code" src="https://github.com/user-attachments/assets/1efa46b7-07cb-4a3e-821d-f23b7a36ab34" /> | <img width="240" alt="WeChat Pay donation QR code" src="https://github.com/user-attachments/assets/19065b1d-ac40-478e-8318-fabb75488c5c" /> | <img width="240" alt="LaTeXSnipper community chat QR code" src="https://github.com/user-attachments/assets/91c30d59-a4a7-4118-b24b-dada0fe002bf" /> |
-
-</details>
 
 ## License
 


### PR DESCRIPTION
Remove only the sponsorship/community details wrappers from both READMEs so donation channels are immediately visible. Preserve all QR images, labels, links, and the image/PDF demo collapsible sections. Validated balanced details tags, all three QR links per README, and git diff --check. Documentation only; no application changes.