### PR TITLE
docs: polish README links and demo presentation

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -9,7 +9,7 @@
 ![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20Linux%20%7C%20macOS-orange?style=flat-square)
 ![License](https://img.shields.io/badge/license-GPLv3-blue?style=flat-square)
 
-**[下载桌面端](https://github.com/SakuraMathcraft/LaTeXSnipper/releases/latest)** · [用户手册](https://github.com/SakuraMathcraft/LaTeXSnipper/releases/latest/download/LaTeXSnipper_User_Manual.pdf) · [常见问题](docs/faq.md) · [功能演示](#功能演示)
+**[下载桌面端](https://github.com/SakuraMathcraft/LaTeXSnipper/releases/latest)** · [用户手册](user_manual/user_manual.md) · [常见问题](docs/faq.md) · [功能演示](#功能演示)
 
 [English](readme.md) · 简体中文
 
@@ -44,7 +44,7 @@ MathCraft OCR：[基准测试结果](https://github.com/SakuraMathcraft/MathCraf
 
 Linux/macOS 使用系统 Python 创建受管理的依赖环境，Windows 使用内置 Python 3.11 模板。`.deb` 声明了 `python3` 和 `python3-venv` 依赖；macOS 若没有可用 Python，请先安装受支持的版本。
 
-权限、模型下载、环境目录及故障排查见 [常见问题](docs/faq.md)、[用户数据位置](docs/user_data_storage.md) 和 [完整用户手册](https://github.com/SakuraMathcraft/LaTeXSnipper/releases/latest/download/LaTeXSnipper_User_Manual.pdf)。
+权限、模型下载、环境目录及故障排查见 [常见问题](docs/faq.md)、[用户数据位置](docs/user_data_storage.md) 和 [完整用户手册](user_manual/user_manual.md)。
 
 ## 功能演示
 
@@ -52,19 +52,13 @@ Linux/macOS 使用系统 Python 创建受管理的依赖环境，Windows 使用�
 
 ![截图识别演示](docs/demos/screenshot-recognition.gif)
 
-<details>
-<summary>图片识别 · 展开演示</summary>
+### 图片识别
 
 ![图片识别演示](docs/demos/image-recognition.gif)
 
-</details>
-
-<details>
-<summary>PDF 识别 · 展开演示</summary>
+### PDF 识别
 
 ![PDF 识别演示](docs/demos/pdf-recognition.gif)
-
-</details>
 
 ## Microsoft Office 插件
 
@@ -88,13 +82,13 @@ Linux/macOS 使用系统 Python 创建受管理的依赖环境，Windows 使用�
 
 接口**默认关闭**。本机客户端从 `automation-api.json` 读取地址和 token；远程访问需显式开启、使用独立密钥，并通过 HTTPS 或加密隧道连接，不要以明文 HTTP 暴露到公网。远程外部模型调用单独授权，可能产生服务商费用。
 
-[API 文档与连接配置](docs/automation_api.md) · [客户端示例](examples/automation/README.md)
+[API 文档与连接配置](docs/automation_api.md) · [客户端示例](examples/automation/)
 
 ## 导出
 
 内置导出覆盖 LaTeX、Markdown 公式、MathML、HTML、Word OMML 和 SVG 代码。在依赖管理中安装可选的 **Pandoc** 层后，可导出 Word、PowerPoint、EPUB、PDF、Typst 等文档；PDF 导出还需要 LaTeX PDF 引擎。
 
-完整格式列表与要求见 [用户手册](https://github.com/SakuraMathcraft/LaTeXSnipper/releases/latest/download/LaTeXSnipper_User_Manual.pdf)。
+完整格式列表与要求见 [用户手册](user_manual/user_manual.md)。
 
 ## 支持者名单
 
@@ -111,10 +105,8 @@ Linux/macOS 使用系统 Python 创建受管理的依赖环境，Windows 使用�
 
 LaTeXSnipper 是免费开源、无广告、无内购的个人项目。如果它对你有帮助，欢迎点亮 Star、分享给有需要的人、[反馈问题](https://github.com/SakuraMathcraft/LaTeXSnipper/issues)，或赞助项目维护。
 
-[LINUX DO 社区](https://linux.do/)
-
 | 支付宝 | 微信 | 中文交流群 |
-|---|---|---|
+|:---:|:---:|:---:|
 | <img width="240" alt="支付宝收款码" src="https://github.com/user-attachments/assets/1efa46b7-07cb-4a3e-821d-f23b7a36ab34" /> | <img width="240" alt="微信收款码" src="https://github.com/user-attachments/assets/19065b1d-ac40-478e-8318-fabb75488c5c" /> | <img width="240" alt="LaTeXSnipper 交流群二维码" src="https://github.com/user-attachments/assets/91c30d59-a4a7-4118-b24b-dada0fe002bf" /> |
 
 ## 许可证

--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@ Turn screenshots, images, PDFs, and handwriting into editable formulas and text.
 ![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20Linux%20%7C%20macOS-orange?style=flat-square)
 ![License](https://img.shields.io/badge/license-GPLv3-blue?style=flat-square)
 
-**[Download](https://github.com/SakuraMathcraft/LaTeXSnipper/releases/latest)** · [User Manual (Chinese PDF)](https://github.com/SakuraMathcraft/LaTeXSnipper/releases/latest/download/LaTeXSnipper_User_Manual.pdf) · [FAQ](docs/faq.md) · [Demos](#demos)
+**[Download](https://github.com/SakuraMathcraft/LaTeXSnipper/releases/latest)** · [User Manual (Chinese)](user_manual/user_manual.md) · [FAQ](docs/faq.md) · [Demos](#demos)
 
 English · [简体中文](README.zh-CN.md)
 
@@ -44,7 +44,7 @@ MathCraft OCR: [benchmark results](https://github.com/SakuraMathcraft/MathCraft-
 
 Linux/macOS use system Python to create the managed dependency environment; Windows uses its bundled Python 3.11 template. The `.deb` declares `python3` and `python3-venv` dependencies. On macOS, install a supported Python version if one is not available.
 
-For permissions, model downloads, environment paths, and troubleshooting, see the [FAQ](docs/faq.md), [user data locations](docs/user_data_storage.md), and [full user manual (Chinese PDF)](https://github.com/SakuraMathcraft/LaTeXSnipper/releases/latest/download/LaTeXSnipper_User_Manual.pdf).
+For permissions, model downloads, environment paths, and troubleshooting, see the [FAQ](docs/faq.md), [user data locations](docs/user_data_storage.md), and [full user manual (Chinese)](user_manual/user_manual.md).
 
 ## Demos
 
@@ -52,19 +52,13 @@ For permissions, model downloads, environment paths, and troubleshooting, see th
 
 ![Screenshot recognition demo](docs/demos/screenshot-recognition.gif)
 
-<details>
-<summary>Image Recognition — view demo</summary>
+### Image Recognition
 
 ![Image recognition demo](docs/demos/image-recognition.gif)
 
-</details>
-
-<details>
-<summary>PDF Recognition — view demo</summary>
+### PDF Recognition
 
 ![PDF recognition demo](docs/demos/pdf-recognition.gif)
-
-</details>
 
 ## Microsoft Office Plugin
 
@@ -88,13 +82,13 @@ Use MathCraft or your configured external model from scripts, batch jobs, editor
 
 The API is **disabled by default**. Local clients use the address and token in `automation-api.json`. Remote access requires explicit opt-in, a separate key, and HTTPS or an encrypted tunnel; do not expose it over plain public HTTP. Remote external-model access is separately controlled and may incur provider charges.
 
-[API reference and connection setup](docs/automation_api.md) · [Ready-to-adapt client examples](examples/automation/README.md)
+[API reference and connection setup](docs/automation_api.md) · [Ready-to-adapt client examples](examples/automation/)
 
 ## Export
 
 Built-in exports cover LaTeX, Markdown math, MathML, HTML, Word OMML, and SVG code. Install the optional **Pandoc** layer in Dependency Management for document exports such as Word, PowerPoint, EPUB, PDF, and Typst. PDF export also requires a LaTeX PDF engine.
 
-See the [user manual](https://github.com/SakuraMathcraft/LaTeXSnipper/releases/latest/download/LaTeXSnipper_User_Manual.pdf) for the full format list and requirements.
+See the [user manual](user_manual/user_manual.md) for the full format list and requirements.
 
 ## Supporters
 
@@ -111,10 +105,8 @@ Thanks to everyone who helps with development, testing, documentation, and commu
 
 LaTeXSnipper is a free, open-source, ad-free personal project with no in-app purchases. If it helps your work, consider starring the repository, sharing it, [reporting an issue](https://github.com/SakuraMathcraft/LaTeXSnipper/issues), or sponsoring maintenance.
 
-[LINUX DO Community](https://linux.do/)
-
 | Alipay | WeChat Pay | Community chat (Chinese) |
-|---|---|---|
+|:---:|:---:|:---:|
 | <img width="240" alt="Alipay donation QR code" src="https://github.com/user-attachments/assets/1efa46b7-07cb-4a3e-821d-f23b7a36ab34" /> | <img width="240" alt="WeChat Pay donation QR code" src="https://github.com/user-attachments/assets/19065b1d-ac40-478e-8318-fabb75488c5c" /> | <img width="240" alt="LaTeXSnipper community chat QR code" src="https://github.com/user-attachments/assets/91c30d59-a4a7-4118-b24b-dada0fe002bf" /> |
 
 ## License


### PR DESCRIPTION
## Summary

Apply the same presentation and link changes to both READMEs:

- Remove the LINUX DO introduction/link.
- Link the user manual to the repository Markdown document using a relative path, instead of downloading a release PDF.
- Link client examples to the relative examples/automation/ directory.
- Display all three recognition demos directly, removing the remaining details/summary wrappers.
- Center the donation/community QR-code table headers and images within their columns.

## Validation

- All local Markdown/image destinations exist.
- Both READMEs contain all three demos, three Markdown manual links, and the relative examples-directory link.
- No remaining collapsible sections, LINUX DO references, or Chinese PDF labels.
- git diff --check passed.
- Documentation only: no GIF or application-code changes; no runtime tests/build needed.