### PR TITLE
docs: restore README QR code width to 300

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -107,7 +107,7 @@ LaTeXSnipper 是免费开源、无广告、无内购的个人项目。如果它�
 
 | 支付宝 | 微信 | 中文交流群 |
 |:---:|:---:|:---:|
-| <img width="240" alt="支付宝收款码" src="https://github.com/user-attachments/assets/1efa46b7-07cb-4a3e-821d-f23b7a36ab34" /> | <img width="240" alt="微信收款码" src="https://github.com/user-attachments/assets/19065b1d-ac40-478e-8318-fabb75488c5c" /> | <img width="240" alt="LaTeXSnipper 交流群二维码" src="https://github.com/user-attachments/assets/91c30d59-a4a7-4118-b24b-dada0fe002bf" /> |
+| <img width="300" alt="支付宝收款码" src="https://github.com/user-attachments/assets/1efa46b7-07cb-4a3e-821d-f23b7a36ab34" /> | <img width="300" alt="微信收款码" src="https://github.com/user-attachments/assets/19065b1d-ac40-478e-8318-fabb75488c5c" /> | <img width="300" alt="LaTeXSnipper 交流群二维码" src="https://github.com/user-attachments/assets/91c30d59-a4a7-4118-b24b-dada0fe002bf" /> |
 
 ## 许可证
 

--- a/readme.md
+++ b/readme.md
@@ -107,7 +107,7 @@ LaTeXSnipper is a free, open-source, ad-free personal project with no in-app pur
 
 | Alipay | WeChat Pay | Community chat (Chinese) |
 |:---:|:---:|:---:|
-| <img width="240" alt="Alipay donation QR code" src="https://github.com/user-attachments/assets/1efa46b7-07cb-4a3e-821d-f23b7a36ab34" /> | <img width="240" alt="WeChat Pay donation QR code" src="https://github.com/user-attachments/assets/19065b1d-ac40-478e-8318-fabb75488c5c" /> | <img width="240" alt="LaTeXSnipper community chat QR code" src="https://github.com/user-attachments/assets/91c30d59-a4a7-4118-b24b-dada0fe002bf" /> |
+| <img width="300" alt="Alipay donation QR code" src="https://github.com/user-attachments/assets/1efa46b7-07cb-4a3e-821d-f23b7a36ab34" /> | <img width="300" alt="WeChat Pay donation QR code" src="https://github.com/user-attachments/assets/19065b1d-ac40-478e-8318-fabb75488c5c" /> | <img width="300" alt="LaTeXSnipper community chat QR code" src="https://github.com/user-attachments/assets/91c30d59-a4a7-4118-b24b-dada0fe002bf" /> |
 
 ## License
 


### PR DESCRIPTION
Restore the three donation/community QR images from width 240 to 300 in both READMEs. Preserve centered table columns, image URLs, and labels. Only two Markdown lines changed; git diff --check passed. No application code or assets changed.